### PR TITLE
removed closing ">" in the wrong location

### DIFF
--- a/components/select/select.ts
+++ b/components/select/select.ts
@@ -41,7 +41,7 @@ let optionsTemplate = `
              class="ui-select-choices-row"
              [class.active]="isActive(o)"
              (mouseenter)="selectActive(o)"
-             (click)="selectMatch(o, $event)">
+             (click)="selectMatch(o, $event)"
              [ngClass]="{'active': isActive(o)}">
           <a href="javascript:void(0)" class="ui-select-choices-row-inner">
             <div [innerHtml]="o.text | hightlight:inputValue"></div>


### PR DESCRIPTION
This caused me to see "[ngClass]="{'active': isActive(o)}">" above the child item. simple fix