### PR TITLE
fixed possible dupes in filter

### DIFF
--- a/components/select/select.ts
+++ b/components/select/select.ts
@@ -464,7 +464,7 @@ export class GenericBehavior extends Behavior implements OptionsBehavior {
       .filter((option:SelectItem) => {
         return stripTags(option.text).match(query) &&
           (this.actor.multiple === false ||
-          (this.actor.multiple === true && this.actor.active.map(item => item.id).indexOf(option.id) < 0));
+          (this.actor.multiple === true && this.actor.active.map((item: SelectItem) => item.id).indexOf(option.id) < 0));
       });
     this.actor.options = options;
     if (this.actor.options.length > 0) {

--- a/components/select/select.ts
+++ b/components/select/select.ts
@@ -464,7 +464,7 @@ export class GenericBehavior extends Behavior implements OptionsBehavior {
       .filter((option:SelectItem) => {
         return stripTags(option.text).match(query) &&
           (this.actor.multiple === false ||
-          (this.actor.multiple === true && this.actor.active.indexOf(option) < 0));
+          (this.actor.multiple === true && this.actor.active.map(item => item.id).indexOf(option.id) < 0));
       });
     this.actor.options = options;
     if (this.actor.options.length > 0) {


### PR DESCRIPTION
If you set initData with one or more items and then write something that matches any of those items in the filterbox, they will still show up in the dropdown.
This fixes that, so that the filter checks the id field instead of the object as a whole.
