### PR TITLE
fix(select): compare the ID of a SelectItem instead of its text

### DIFF
--- a/components/select/select.ts
+++ b/components/select/select.ts
@@ -422,7 +422,7 @@ export class SelectComponent implements OnInit {
   }
 
   protected  isActive(value:SelectItem):boolean {
-    return this.activeOption.text === value.text;
+    return this.activeOption.id === value.id;
   }
 
   private focusToInput(value:string = ''):void {


### PR DESCRIPTION
When hovering over an item with a not unique text, all other items will be marked as active. It creates a visual glitch. This PR uses an ID of items, that is most likely to be unique (depending on the consumer implementation).

<img width="594" alt="evokly___v1_3_5" src="https://cloud.githubusercontent.com/assets/1478684/17741281/e0fea72c-649b-11e6-9253-027609fae6b9.png">
This picture illustrates the problem. Only one of the `[Pop-up] AAAby` is hovered, but both of them are marked as active.
