### PR TITLE
(fix) remove handle click behaviour on single mode

### DIFF
--- a/components/select/select.ts
+++ b/components/select/select.ts
@@ -122,7 +122,7 @@ let styles = `
               [innerHTML]="sanitize(active[0].text)"></span>
         <i class="dropdown-toggle pull-right"></i>
         <i class="caret pull-right"></i>
-        <a *ngIf="allowClear && active.length>0" class="btn btn-xs btn-link pull-right" style="margin-right: 10px; padding: 0;" (click)="remove(activeOption)">
+        <a *ngIf="allowClear && active.length>0" class="btn btn-xs btn-link pull-right" style="margin-right: 10px; padding: 0;" (click)="removeClick(active[0], $event)">
            <i class="glyphicon glyphicon-remove"></i>
         </a>
       </span>
@@ -183,7 +183,7 @@ let styles = `
                   [ngClass]="{'btn-default': true}">
                <a class="close"
                   style="margin-left: 5px; padding: 0;"
-                  (click)="remove(a)">&times;</a>
+                  (click)="removeClick(a, $event)">&times;</a>
                <span>{{a.text}}</span>
            </span>
         </span>
@@ -479,6 +479,11 @@ export class SelectComponent implements OnInit {
 
   protected  isActive(value:SelectItem):boolean {
     return this.activeOption.text === value.text;
+  }
+
+  protected removeClick(value: SelectItem, event: any): void {
+    event.stopPropagation();
+    this.remove(value);
   }
 
   private focusToInput(value:string = ''):void {


### PR DESCRIPTION
The issue:

I am using SelectComponent with `multiple=false` `allowClear=true`
When I set `active` programatically and then user clicks `remove` icon, `remove` event is not emitted. This is because wrong property was passed to `remove` function.

This PR then also prevents opening up options when user clicks `remove` icon - this happened because click event was not caught and was propagated to parent element.
