### PR TITLE
Add output for "opened" state to component

### DIFF
--- a/components/select/select.ts
+++ b/components/select/select.ts
@@ -293,6 +293,7 @@ export class SelectComponent implements OnInit {
   @Output() public selected:EventEmitter<any> = new EventEmitter();
   @Output() public removed:EventEmitter<any> = new EventEmitter();
   @Output() public typed:EventEmitter<any> = new EventEmitter();
+  @Output() public opened:EventEmitter<any> = new EventEmitter();
 
   public options:Array<SelectItem> = [];
   public itemObjects:Array<SelectItem> = [];
@@ -303,8 +304,17 @@ export class SelectComponent implements OnInit {
     return this._active;
   }
 
+  private set optionsOpened(value:boolean){
+    this._optionsOpened = value;
+    this.opened.emit(value);
+  }
+
+  private get optionsOpened(): boolean{
+    return this._optionsOpened;
+  }
+
   private inputMode:boolean = false;
-  private optionsOpened:boolean = false;
+  private _optionsOpened:boolean = false;
   private behavior:OptionsBehavior;
   private inputValue:string = '';
   private _items:Array<any> = [];


### PR DESCRIPTION
For some strange reason a2 change-detection is not always triggered if the component is clicked. This sometimes causes the options-dropdown to be displayed/hidden with delay.

Adding this feature would allow us to be notified whenever the options-dropdown visibility changes. Beside from the practical use of such an event, this would allow us to call change-detection manually in such cases.