### PR TITLE
#557: Fix rendering select component on firefox

### DIFF
--- a/components/select/select.ts
+++ b/components/select/select.ts
@@ -9,6 +9,11 @@ let styles = `
   .ui-select-toggle {
     position: relative;
   }
+
+  /* Fix caret going into new line in Firefox */
+  .ui-select-placeholder {
+    float: left;
+  }
   
   /* Fix Bootstrap dropdown position when inside a input-group */
   .input-group > .dropdown {


### PR DESCRIPTION
#557: Fixed visual error on firefox. In single-select mode select
component had extended height due to caret symbol going into new line.
Added float:left to placeholder class to fix this.