### PR TITLE
Fixed Issue where if the ID is 0 the text is used instead

### DIFF
--- a/components/select/select-item.ts
+++ b/components/select/select-item.ts
@@ -9,7 +9,8 @@ export class SelectItem {
       this.id = this.text = source;
     }
     if (typeof source === 'object') {
-      this.id = source.id || source.text;
+      if(source.id === null || source.id === "")this.id = source.text;
+      else this.id = source.id;
       this.text = source.text;
       if (source.children && source.text) {
         this.children = source.children.map((c:any) => {


### PR DESCRIPTION
When doing the null check of id, it also catches 0, which is a valid ID in certain use-cases. Here i check against null and a empty string to fix it.