### PR TITLE
Fix search

### DIFF
--- a/src/select/select.ts
+++ b/src/select/select.ts
@@ -764,7 +764,7 @@ export class ChildrenBehavior extends Behavior implements OptionsBehavior {
     let optionsMap: Map<string, number> = new Map<string, number>();
     let startPos = 0;
     for (let si of this.actor.itemObjects) {
-      let children: Array<SelectItem> = si.children.filter((option: SelectItem) => query.test(option.text));
+      let children: Array<SelectItem> = si.children.filter((option: SelectItem) => stripTags(option.text).match(query));
       startPos = si.fillChildrenHash(optionsMap, startPos);
       if (children.length > 0) {
         let newSi = si.getSimilar();


### PR DESCRIPTION
Fixes this issue: https://github.com/valor-software/ng2-select/issues/915

The original query.test() keeps a global variable that interferes with evaluation of consequitive strings. Refere to example here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test

Basically, if the si.children array contains [ "hello", "llo" ], and we search for "llo", it will not find the second item, as regex.lastIndex is set to 2.

This will make the code consistent with GenericBehavior.filter().